### PR TITLE
2.0.1

### DIFF
--- a/checks/check_auto_downtimes_arg_thingy
+++ b/checks/check_auto_downtimes_arg_thingy
@@ -19,6 +19,7 @@
 #   Copyright (C) 2024  SVA System Vertrieb Alexander GmbH
 #                       by michael.hoess@sva.de + colleagues
 
+import os
 
 def arguments_maintenance(params):
     args = []
@@ -37,6 +38,11 @@ def arguments_maintenance(params):
                 args += ["--verify_ssl"]
             if no_proxy:
                 args += ["--no_proxy"]
+    else:
+        args += ["--omd_host", "127.0.0.1"]
+        args += ["--omd_port", "5000"]
+        args += ["--omd_site", os.getenv("OMD_SITE")]
+        args += ["--no_proxy"]
 
     if "display_service_name" in params:
         args += ["--display_service_name", params["display_service_name"]]

--- a/web/plugins/wato/auto_downtimes_active_check_rule.py
+++ b/web/plugins/wato/auto_downtimes_active_check_rule.py
@@ -400,7 +400,7 @@ _valuespec_maintenance_elements = [
         Checkbox(
             title=_("Enable debugging"),
             help=_(
-                "Enable debugging to ~/tmp/maintenance.py.log. Only enable on problems, may fill up your filesystem and eat performance!"
+                "Enable debugging to ~/tmp/auto_downtimes.log. Only enable on problems, may fill up your filesystem and eat performance!"
             ),
             default_value=False,
         ),


### PR DESCRIPTION
This will

- rename the help text where the name of the log is wrong
- fix the input arguments in situations where we do not have a distributed monitoring. Otherwise we get a 'Failed to establish a new connection: [Errno 111] Connection refused' error on localhost and port 443.

Regards
Marcel ;)